### PR TITLE
Fix/hang on overlap fitting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.1.11 (2020-05-21)
+-------------------
+- Limited the number of lines to try to pair during overlap fitting (to 20 from blue and 15 from the red side). This addresses a bug whereby overlap fitting would stall indefinitely if there were too many pairs of lines to try.
+
 0.1.10 (2020-04-23)
 -------------------
 - Removed peakutils requirement. Updated astropy and scipy dependencies.
@@ -65,3 +69,4 @@ in the config.ini file and have associated custom sets of reduction stages.
 0.1.0 (2019-10-20)
 -------------------
 - Initial release.
+

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(name='xwavecal',
       author='G. Mirek Brandt, Curtis McCully, Timothy Brandt',
       author_email='gmbrandt@ucsb.edu',
-      version='0.1.10',
+      version='0.1.11',
       python_requires='>=3.6',
       url='https://github.com/gmbrandt/xwavecal',
       packages=find_packages(),

--- a/xwavecal/utils/overlap_utils.py
+++ b/xwavecal/utils/overlap_utils.py
@@ -30,8 +30,8 @@ class OverlapFitter:
         #r_lines_flux = np.sort(r_lines_flux)[::-1][:15]
         r_lines_flux = r_lines_flux[np.argsort(r_lines)][:15]
         r_lines = np.sort(r_lines)[:15]
-        b_lines_flux = b_lines_flux[np.argsort(b_lines)]
-        b_lines = np.sort(b_lines)
+        b_lines_flux = b_lines_flux[np.argsort(b_lines)][-20:]
+        b_lines = np.sort(b_lines)[-20:]
         # build nearest function for finding matching blue peaks.
         nearest_blue = interpolate.interp1d(b_lines, b_lines, kind='nearest', bounds_error=False,
                                             fill_value=(np.min(b_lines), np.max(b_lines)))


### PR DESCRIPTION
This PR fixes indefinite stalls on overlap fitting when there are too many lines from the blue side to try and pair up with lines on the red side.